### PR TITLE
Add two files associated with jailbreaks

### DIFF
--- a/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -34,6 +34,7 @@ Check for files and directories typically associated with jailbreaks, such as:
 /private/var/mobile/Library/SBSettings/Themes
 /private/var/stash
 /private/var/tmp/cydia.log
+/var/tmp/cydia.log
 /usr/bin/sshd
 /usr/libexec/sftp-server
 /usr/libexec/ssh-keysign
@@ -45,6 +46,7 @@ Check for files and directories typically associated with jailbreaks, such as:
 /usr/bin/cycript
 /usr/local/bin/cycript
 /usr/lib/libcycript.dylib
+/var/log/syslog
 ```
 
 ##### Checking File Permissions


### PR DESCRIPTION
There is [list of files associated with jailbreaks](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/jailbreak-detection-methods/) from trustwave has two additional files to check:

* /var/tmp/cydia.log
* /var/log/syslog

Here is more evidence regarding /var/log/syslog is related to jailbreak tools: https://www.theiphonewiki.com/wiki/System_Log#On-device_with_saving_to_a_file

I haven't found an alternative supporting evidence for the /var/tmp/cydia.log file, I'm trusting trustwave reference in this case.

Feel free to discuss, and of course I can remove this file from the commit if there isn't enough information supporting it's related to jailbreak.

